### PR TITLE
No paragraphs with only idx

### DIFF
--- a/ptx/sec_counting-addmult.ptx
+++ b/ptx/sec_counting-addmult.ptx
@@ -171,7 +171,9 @@
       <title>Multiplicative Principle</title>
       <p permid="dMX">
         The
-        <term>multiplicative principle</term><idx><h>multiplicative principle</h></idx> states that if event <m>A</m> can occur in <m>m</m> ways,
+        <term>multiplicative principle</term>
+            <idx><h>multiplicative principle</h></idx>
+        states that if event <m>A</m> can occur in <m>m</m> ways,
         and each possibility for <m>A</m> allows for exactly <m>n</m> ways for event <m>B</m>,
         then the event <q><m>A</m> and <m>B</m></q>
         can occur in <m>m \cdot n</m> ways.
@@ -400,7 +402,9 @@
       <title>Additive Principle (with sets)</title>
       <p permid="ngJ">
             <idx><h>additive principle</h></idx>
-        Given two sets <m>A</m> and <m>B</m>, if <m>A \cap B = \emptyset</m> (that is, if there is no element in common to both <m>A</m> and <m>B</m>), then
+        Given two sets <m>A</m> and <m>B</m>, if <m>A \cap B = \emptyset</m>
+        (that is, if there is no element in common to both <m>A</m> and <m>B</m>),
+        then
         <me permid="KEa">
           \card{A \cup B} = \card{A} + \card{B}
         </me>.
@@ -428,7 +432,8 @@
       <title>Cartesian Product</title>
       <p permid="fCk">
         Given sets <m>A</m> and <m>B</m>, we can form the
-        <em>set</em> <m>A \times B = \{(x,y) \st x \in A \wedge y \in B\}</m> to be the set of all ordered pairs <m>(x,y)</m> where <m>x</m> is an element of <m>A</m> and <m>y</m> is an element of <m>B</m>.
+        <em>set</em> <m>A \times B = \{(x,y) \st x \in A \wedge y \in B\}</m> to be the set of all ordered pairs
+        <m>(x,y)</m> where <m>x</m> is an element of <m>A</m> and <m>y</m> is an element of <m>B</m>.
         We call <m>A \times B</m> the
         <term>Cartesian product</term>
             <idx><h>Cartesian product</h></idx>
@@ -501,7 +506,8 @@
       <title>Multiplicative Principle (with sets)</title>
       <p permid="Qtm">
             <idx><h>multiplicative principle</h></idx>
-        Given two sets <m>A</m> and <m>B</m>, we have <m>\card{A \times B} = \card{A} \cdot \card{B}</m>.
+        Given two sets <m>A</m> and <m>B</m>,
+        we have <m>\card{A \times B} = \card{A} \cdot \card{B}</m>.
       </p>
     </assemblage>
 

--- a/ptx/sec_gt-intro.ptx
+++ b/ptx/sec_gt-intro.ptx
@@ -456,16 +456,19 @@
   </p>
 
   <assemblage permid="pGq">
+      <idx><h>isomorphic</h></idx>
     <title>Isomorphic Graphs</title>
     <p permid="QmI">
-          <idx><h>isomorphic</h></idx>
-      An
-			<term>isomorphism</term><idx><h>isomorphism</h></idx> between two graphs <m>G_1</m> and <m>G_2</m> is a bijection <m>f:V_1 \to V_2</m> between the vertices of the graphs such that if <m>\{a,b\}</m> is an edge in <m>G_1</m> then <m>\{f(a), f(b)\}</m> is an edge in <m>G_2</m>.
+      An <term>isomorphism</term>
+          <idx><h>isomorphism</h></idx>
+      between two graphs <m>G_1</m> and <m>G_2</m> is a bijection
+      <m>f:V_1 \to V_2</m> between the vertices of the graphs such that
+      if <m>\{a,b\}</m> is an edge in <m>G_1</m> then <m>\{f(a), f(b)\}</m> is an edge in <m>G_2</m>.
     </p>
 
     <p permid="wtR">
-      Two graphs are
-			<term>isomorphic</term> if there is an isomorphism between them. In this case we write <m>G_1 \isom G_2</m>.
+      Two graphs are <term>isomorphic</term> if there is an isomorphism between them.
+      In this case we write <m>G_1 \isom G_2</m>.
     </p>
   </assemblage>
 
@@ -680,9 +683,9 @@
 
   <assemblage permid="VNz">
     <title>Subgraphs</title>
+      <idx><h>subgraph</h></idx>
     <p permid="cBa">
       We say that <m>G' = (V', E')</m> is a <term>subgraph</term>
-          <idx><h>subgraph</h></idx>
       of <m>G = (V, E)</m>, and write <m>G' \subseteq G</m>,
       provided <m>V' \subseteq V</m> and <m>E' \subseteq E</m>.
     </p>
@@ -792,9 +795,9 @@
   </p>
 
   <p permid="bvH">
-    The graphs above are also <term>connected</term>
+    The graphs above are also <term>connected</term>:
         <idx><h>connected</h></idx>
-    : you can get from any vertex to any other vertex by following some path of edges.
+    you can get from any vertex to any other vertex by following some path of edges.
     A graph that is not connected can be thought of as two separate graphs drawn close together.
     For example,
     the following graph is NOT connected because there is no path from <m>a</m> to <m>b</m>:
@@ -1027,8 +1030,9 @@
           <p permid="tUK">
               <idx><h>graph</h></idx>
           A collection of
-						<term>vertices</term>, some of which are connected by
-						<term>edges</term>. More precisely, a pair of sets <m>V</m> and <m>E</m> where <m>V</m> is a set of vertices and <m>E</m> is a set of 2-element subsets of <m>V</m>.
+          <term>vertices</term>, some of which are connected by
+          <term>edges</term>.
+          More precisely, a pair of sets <m>V</m> and <m>E</m> where <m>V</m> is a set of vertices and <m>E</m> is a set of 2-element subsets of <m>V</m>.
           </p>
         </li>
 
@@ -1037,8 +1041,9 @@
           <p permid="abT">
               <idx><h>adjacent</h></idx>
           Two vertices are
-						<term>adjacent</term> if they are connected by an edge. Two edges are
-						<term>adjacent</term> if they share a vertex.
+          <term>adjacent</term> if they are connected by an edge.
+          Two edges are
+          <term>adjacent</term> if they share a vertex.
           </p>
         </li>
 
@@ -1070,7 +1075,7 @@
           <p permid="yED">
               <idx><h>connected</h></idx>
           A graph is
-						<term>connected</term> if there is a path from any vertex to any other vertex.
+          <term>connected</term> if there is a path from any vertex to any other vertex.
           </p>
         </li>
 
@@ -1101,6 +1106,7 @@
         <li permid="TCN">
           <title>Euler path</title>
           <p permid="Xhn">
+              <idx><h>Euler path</h></idx>
             A walk which uses each edge exactly once.
           </p>
         </li>
@@ -1108,7 +1114,7 @@
         <li permid="zJW">
           <title>Euler circuit</title>
           <p permid="Dow">
-              <idx><h>Euler path</h></idx>
+              <idx><h>Euler circuit</h></idx>
           An Euler path which starts and stops at the same vertex.
           </p>
         </li>
@@ -1118,14 +1124,15 @@
           <p permid="jvF">
               <idx><h>multigraph</h></idx>
           A
-						<term>multigraph</term> is just like a graph but can contain multiple edges between two vertices as well as single edge loops (that is an edge from a vertex to itself).
+          <term>multigraph</term>
+          is just like a graph but can contain multiple edges between two vertices as well as single edge loops
+          (that is an edge from a vertex to itself).
           </p>
         </li>
 
         <li permid="LYo">
           <title>Path</title>
               <idx><h>path</h></idx>
-
           <p permid="PCO">
             A <term>path</term> is a walk that doesn't repeat any vertices
             (or edges)
@@ -1147,9 +1154,12 @@
           <title>Subgraph</title>
           <p permid="bRg">
               <idx><h>subgraph</h></idx>
-          We say that <m>H</m> is a
-						<term>subgraph</term> of <m>G</m> if every vertex and edge of <m>H</m> is also a vertex or edge of <m>G</m>. We say <m>H</m> is an
-						<term>induced</term> subgraph of <m>G</m> if every vertex of <m>H</m> is a vertex of <m>G</m> and each pair of vertices in <m>H</m> are adjacent in <m>H</m> if and only if they are adjacent in <m>G</m>.
+            We say that <m>H</m> is a
+            <term>subgraph</term> of <m>G</m> if every vertex and edge of <m>H</m> is also a vertex or edge of <m>G</m>.
+            We say <m>H</m> is an
+            <term>induced</term> subgraph of <m>G</m> if every vertex of <m>H</m> is a vertex of <m>G</m>
+            and
+            each pair of vertices in <m>H</m> are adjacent in <m>H</m> if and only if they are adjacent in <m>G</m>.
           </p>
         </li>
 
@@ -1157,9 +1167,9 @@
           <title>Tree</title>
           <p permid="HYp">
               <idx><h>tree</h></idx>
-          A (connected) graph with no cycles. (A non-connected graph with no cycles is called a
-						<term>forest</term>.) The vertices in a tree with degree 1 are called
-						<term>leaves</term>.
+            A (connected) graph with no cycles. (A non-connected graph with no cycles is called a
+            <term>forest</term>.) The vertices in a tree with degree 1 are called
+            <term>leaves</term>.
           </p>
         </li>
 
@@ -1169,7 +1179,7 @@
               <idx><h>vertex coloring</h></idx>
           An assignment of colors to each of the vertices of a graph.
             A vertex coloring is
-						<term>proper</term> if adjacent vertices are always colored differently.
+      <term>proper</term> if adjacent vertices are always colored differently.
           </p>
         </li>
 
@@ -1177,7 +1187,7 @@
           <title>Walk</title>
           <p permid="UmH">
               <idx><h>walk</h></idx>
-          A sequence of vertices such that consecutive vertices (in the sequence) are adjacent (in the graph).
+            A sequence of vertices such that consecutive vertices (in the sequence) are adjacent (in the graph).
             A walk in which no edge is repeated is called a <term>trail</term>,
             and a trail in which no vertex is repeated
             (except possibly the first and last)

--- a/ptx/sec_gt-matchings.ptx
+++ b/ptx/sec_gt-matchings.ptx
@@ -144,8 +144,8 @@
 
   <assemblage permid="tdM">
     <title>Matching Condition</title>
+      <idx><h>matching condition</h></idx>
     <p permid="uSZ">
-          <idx><h>matching condition</h></idx>
       If a bipartite graph <m>G = \{A, B\}</m> has a matching of <m>A</m>, then
       <me permid="ktU">
         |N(S)| \ge |S|
@@ -172,9 +172,9 @@
 
   <theorem permid="ZkV">
     <title>Hall's Marriage Theorem</title>
+      <idx><h>Hall's Marriage Theorem</h></idx>
     <statement>
       <p permid="qjg">
-            <idx><h>Hall's Marriage Theorem</h></idx>
         Let <m>G</m> be a bipartite graph with sets <m>A</m> and <m>B</m>.
         Then <m>G</m> has a matching of <m>A</m> if and only if
         <me permid="QBd">

--- a/ptx/sec_gt-planar.ptx
+++ b/ptx/sec_gt-planar.ptx
@@ -150,12 +150,12 @@
     <assemblage permid="UPx">
       <title>Euler's Formula for Planar Graphs</title>
       <p permid="Fla">
-            <idx><h>Euler's formula</h></idx>
         For any (connected) planar graph with <m>v</m> vertices,
         <m>e</m> edges and <m>f</m> faces, we have
         <me permid="EfH">
           v-e + f = 2
         </me>
+            <idx><h>Euler's formula</h></idx>
       </p>
     </assemblage>
 
@@ -428,9 +428,8 @@
         It contains 6 identical squares for its faces, 8 vertices,
         and 12 edges.
         The cube is a <term>regular polyhedron</term>
-        (also known as a <term>Platonic solid</term>
-            <idx><h>Platonic solids</h></idx>
-        )
+        (also known as a <term>Platonic solid</term>)
+            <idx><h>Platonic solid</h></idx>
         because each face is an identical regular polygon and each vertex joins an equal number of faces.
       </p>
 

--- a/ptx/sec_intro-functions.ptx
+++ b/ptx/sec_intro-functions.ptx
@@ -466,10 +466,10 @@
     </p>
 
     <p permid="fau">
-          <idx><h>closed formula</h><h>for a function</h></idx>
       Giving an explicit formula that calculates the image of any element in the domain is a great way to describe a function.
       We will say that these explicit rules are
       <term>closed formulas</term> for the function.
+          <idx><h>closed formula</h><h>for a function</h></idx>
     </p>
 
     <p permid="LhD">
@@ -532,7 +532,7 @@
 
     <assemblage permid="GEO">
       <title>Recursively Defined Functions</title>
-      <idx><h>recursively defined functions</h></idx>
+        <idx><h>recursively defined functions</h></idx>
 
       <p permid="XvV">
         For a function <m>f:\N \to \N</m>,

--- a/ptx/sec_intro-sets.ptx
+++ b/ptx/sec_intro-sets.ptx
@@ -188,9 +188,7 @@
             <li permid="iTp">
               <p permid="IPN">
                 This is the set of all integers
-                <idx>
-                <h>integers</h>
-                </idx>
+                    <idx><h>integers</h></idx>
                 (positive and negative whole numbers, written <m>\Z</m>).
                 In other words, <m>\{\ldots, -2, -1, 0, 1, 2, \ldots\}</m>.
               </p>
@@ -228,7 +226,7 @@
                 <description>the empty set</description>
               </notation>
 
-                <idx> <h>empty set</h> </idx>
+                <idx><h>empty set</h></idx>
             </p>
           </li>
 
@@ -249,17 +247,14 @@
             <title><m>\N</m></title>
             <p permid="hsx">
               The set of natural numbers.
-              That is, <m>\N =
-              \{0, 1, 2, 3\ldots\}</m>.
+              That is, <m>\N = \{0, 1, 2, 3\ldots\}</m>.
 
               <notation>
                 <usage>\N</usage>
-                <description>the set
-                of natural numbers</description>
+                <description>the set of natural numbers</description>
               </notation>
 
-              <idx><h>natural
-              numbers</h></idx>
+              <idx><h>natural numbers</h></idx>
             </p>
           </li>
 
@@ -269,11 +264,10 @@
               The set of
               integers.
               That is, <m>\Z = \{\ldots, -2, -1, 0, 1, 2, 3, \ldots\}</m>.
-                <idx> <h>integers</h> </idx>
-            <notation>
+                <idx><h>integers</h></idx>
+              <notation>
                 <usage>\Z</usage>
-                <description>the
-                set of integers</description>
+                <description>the set of integers</description>
               </notation>
 
             </p>
@@ -289,7 +283,7 @@
                 <description>the set of rational numbers</description>
               </notation>
 
-                <idx> <h>rationals</h> </idx>
+                <idx><h>rationals</h></idx>
             </p>
           </li>
 
@@ -297,12 +291,12 @@
             <title><m>\R</m></title>
             <p permid="ZNY">
               The set of real numbers.
-                <idx><h>reals</h> </idx>
-            <notation>
+              <notation>
                 <usage>\R</usage>
                 <description>the set of real numbers</description>
               </notation>
 
+                <idx><h>reals</h></idx>
             </p>
           </li>
 
@@ -310,8 +304,8 @@
             <title><m>\pow(A)</m></title>
             <p permid="FVh">
               The <term>power set</term> of any set <m>A</m> is the set of all subsets of <m>A</m>.
-                <idx> <h>power set</h> </idx>
-            <notation>
+                  <idx><h>power set</h></idx>
+              <notation>
                 <usage>\pow(A)</usage>
                 <description>the power set of <m>A</m></description>
               </notation>
@@ -420,7 +414,7 @@
                 <description>set intersection</description>
               </notation>
 
-                <idx> <h>intersection</h> </idx>
+                <idx><h>intersection</h></idx>
             </p>
           </li>
 
@@ -435,7 +429,7 @@
                 <description>set union</description>
               </notation>
 
-                <idx> <h>union</h> </idx>
+                <idx><h>union</h></idx>
             </p>
           </li>
 
@@ -493,7 +487,7 @@
                 <description>cardinality (size) of <m>A</m></description>
               </notation>
 
-                <idx> <h>cardinality</h></idx>
+                <idx><h>cardinality</h></idx>
             </p>
           </li>
         </dl>
@@ -579,9 +573,8 @@
       Clearly <m>A \ne B</m>,
       but notice that every element of <m>A</m> is also an element of <m>B</m>.
       Because of this we say that <m>A</m> is a <em>subset</em>
-      <idx>
-      <h>subset</h>
-      </idx> of <m>B</m>, or in symbols
+          <idx><h>subset</h></idx>
+      of <m>B</m>, or in symbols
       <m>A \subset B</m> or <m>A \subseteq B</m>.
       Both symbols are read <q>is a subset of.</q>
       The difference is that sometimes we want to say that <m>A</m> is either equal to or is a subset of <m>B</m>,
@@ -697,9 +690,8 @@
       If you collect all these subsets of <m>A</m> into a new set,
       we get a set of sets.
       We call the set of all subsets of <m>A</m> the <term>power set</term>
-      <idx>
-      <h>power set</h>
-      </idx> of <m>A</m>, and write it <m>\pow(A)</m>.
+          <idx><h>power set</h></idx>
+      of <m>A</m>, and write it <m>\pow(A)</m>.
     </p>
 
     <example permid="uxN">
@@ -744,7 +736,7 @@
       and <m>D</m> all have 3 elements.
       The size of a set is called the set's
       <term>cardinality</term> .
-          <idx> <h>cardinality</h> </idx>
+          <idx><h>cardinality</h></idx>
       We would write <m>|A| = 6</m>,
       <m>|B| = 3</m>, and so on.
       For sets that have a finite number of elements,
@@ -831,9 +823,8 @@
       Not really, however there is something similar.
       If we want to combine two sets to get the collection of objects that are in either set,
       then we can take the <term>union</term>
-      <idx>
-      <h>union</h>
-      </idx> of the two sets.
+          <idx><h>union</h></idx>
+      of the two sets.
       Symbolically,
       <me permid="XhN">
         C = A \cup B
@@ -847,15 +838,14 @@
     </p>
 
     <p permid="zKw">
-      The other common operation on sets is <term>intersection</term>
-      <idx>
-      <h>intersection</h>
-      </idx>.
+      The other common operation on sets is <term>intersection</term>.
+          <idx><h>intersection</h></idx>
       We write,
       <me permid="DoW">
         C = A \cap B
       </me>
-      and say, <q><m>C</m> is the intersection of <m>A</m> and <m>B</m>,</q>
+      and say,
+      <q><m>C</m> is the intersection of <m>A</m> and <m>B</m>,</q>
       when the elements in <m>C</m> are precisely those both in <m>A</m> and in <m>B</m>.
       So if <m>A = \{1, 2, 3\}</m> and <m>B = \{2, 3, 4\}</m>,
       then <m>A \cap B = \{2, 3\}</m>.
@@ -872,9 +862,8 @@
       we might wish to speak of all the elements which are
       <em>not</em> in a particular set.
       We say <m>B</m> is the <term>complement</term>
-      <idx>
-      <h>complement</h>
-      </idx> of <m>A</m>, and write,
+          <idx><h>complement</h></idx>
+      of <m>A</m>, and write,
       <me permid="jwf">
         B = \bar A
       </me>
@@ -897,13 +886,9 @@
       What have we done?
       We've started with <m>A</m> and removed all of the elements which were in <m>B</m>.
       Another way to write this is the
-      <term>set difference</term>
-      <idx>
-      <h>set difference</h>
-      </idx>
-      <idx>
-      <h>difference, of sets</h>
-      </idx>:
+      <term>set difference</term>:
+          <idx><h>set difference</h></idx>
+          <idx><h>difference, of sets</h></idx>
       <me permid="vKx">
         A \cap \bar B = A \setminus B
       </me>.
@@ -1030,14 +1015,14 @@
       There is one more way to combine sets which will be useful for us:
       the <term>Cartesian product</term>,
           <idx><h>Cartesian product</h></idx>
-      <m>A \times B</m>
+      <m>A \times B</m>.
 
       <notation>
         <usage>A\times B</usage>
         <description>the Cartesian product of <m>A</m> and <m>B</m></description>
       </notation>
 
-      . This sounds fancy but is nothing you haven't seen before.
+      This sounds fancy but is nothing you haven't seen before.
       When you graph a function in calculus,
       you graph it in the Cartesian plane.
       This is the set of all ordered pairs of real numbers <m>(x,y)</m>.
@@ -1090,10 +1075,9 @@
   <subsection permid="JGL">
     <title>Venn Diagrams</title>
     <p permid="Jei">
-      <idx>
-      <h>Venn diagram</h>
-      </idx> There is a very nice visual tool we can use to represent operations on sets.
+      There is a very nice visual tool we can use to represent operations on sets.
       A <term>Venn diagram</term> displays sets as intersecting circles.
+          <idx><h>Venn diagram</h></idx>
       We can shade the region we are talking about when we carry out an operation.
       We can also represent cardinality of a particular set by putting the number in the corresponding region.
     </p>

--- a/ptx/sec_intro-statements.ptx
+++ b/ptx/sec_intro-statements.ptx
@@ -53,9 +53,9 @@
   <subsection permid="dGT" xml:id="atomic-molecular-statements">
     <title>Atomic and Molecular Statements</title>
     <p permid="zRN">
-      A <term>statement</term><idx>
-      <h>statement</h>
-      </idx> is any declarative sentence which is either true or false.
+      A <term>statement</term>
+          <idx><h>statement</h></idx>
+      is any declarative sentence which is either true or false.
       A statement is
       <term>atomic</term> if it cannot be divided into smaller statements,
       otherwise it is called
@@ -157,8 +157,7 @@
       You can build more complicated (molecular) statements out of simpler
       (atomic or molecular)
       ones using
-      <term>logical connectives</term>
-      .
+      <term>logical connectives</term>.
           <idx><h>connectives</h></idx>
       For example, this is a molecular statement:
     </p>
@@ -229,7 +228,7 @@
             <m>P \wedge Q</m> is read <q><m>P</m> and <m>Q</m>,</q>
             and called a <term>conjunction</term>.
                 <idx><h>conjunction</h></idx>
-                <idx><h>connectives</h><h>and</h> </idx>
+                <idx><h>connectives</h><h>and</h></idx>
 
             <notation>
               <usage>\wedge</usage>
@@ -241,8 +240,8 @@
           <li permid="ujF">
             <m>P \vee Q</m> is read <q><m>P</m> or <m>Q</m>,</q>
             and called a <term>disjunction</term>.
-                <idx> <h>disjunction</h> </idx>
-                <idx> <h>connectives</h> <h>or</h> </idx>
+                <idx><h>disjunction</h></idx>
+                <idx><h>connectives</h><h>or</h></idx>
 
             <notation>
               <usage>\vee</usage>
@@ -255,25 +254,25 @@
             <m>P \imp Q</m> is read <q>if <m>P</m> then <m>Q</m>,</q>
             and called an <term>implication</term>
             or <term>conditional</term>.
-                <idx> <h>implication</h> </idx>
-                <idx> <h>conditional</h> </idx>
-                <idx> <h>connectives</h> <h>implies</h> </idx>
-                <idx> <h>if<ellipsis/>, then<ellipsis/></h> </idx>
+                <idx><h>implication</h></idx>
+                <idx><h>conditional</h></idx>
+                <idx><h>connectives</h><h>implies</h></idx>
+                <idx><h>if<ellipsis/>, then<ellipsis/></h></idx>
           </li>
 
           <li permid="GxX">
             <m>P \iff Q</m> is read <q><m>P</m> if and only if <m>Q</m>,</q>
             and called a <term>biconditional</term>.
-                <idx> <h>biconditional</h> </idx>
-                <idx> <h>connectives</h> <h>if and only if</h> </idx> 
-                <idx> <h>if and only if</h> </idx>
+                <idx><h>biconditional</h></idx>
+                <idx><h>connectives</h><h>if and only if</h></idx> 
+                <idx><h>if and only if</h></idx>
         </li>
 
           <li permid="mFg">
             <m>\neg P</m> is read <q>not <m>P</m>,</q>
             and called a <term>negation</term>.
-                <idx> <h>negation</h> </idx>
-                <idx> <h>connectives</h> <h>not</h> </idx>
+                <idx><h>negation</h></idx>
+                <idx><h>connectives</h><h>not</h></idx>
 
             <notation>
               <usage>\neg</usage>
@@ -320,7 +319,7 @@
     <p permid="wXh">
       Note that for us, <em>or</em> is the
       <term>inclusive or</term> 
-          <idx> <h>inclusive or</h> </idx>
+          <idx><h>inclusive or</h></idx>
       (and not the sometimes used <em>exclusive or</em>) meaning that
       <m>P \vee Q</m> is in fact true when both <m>P</m> and <m>Q</m> are true.
       As for the other connectives,
@@ -342,10 +341,10 @@
     <title>Implications</title>
     <assemblage permid="iqM">
       <title>Implications</title>
-      <idx>antecedent</idx>
-      <idx>consequent</idx>
-      <idx>hypothesis</idx>
-      <idx>conclusion</idx>
+        <idx>antecedent</idx>
+        <idx>consequent</idx>
+        <idx>hypothesis</idx>
+        <idx>conclusion</idx>
 
       <p permid="deq">
         An <term>implication</term> or <term>conditional</term>
@@ -641,9 +640,8 @@
             <p permid="XaJ">
               The
               <term>converse</term>
-              <idx>
-              <h>converse</h>
-              </idx> of an implication
+                  <idx><h>converse</h></idx>
+              of an implication
               <m>P \imp Q</m> is the implication
               <m>Q \imp P</m>.
               The converse is
@@ -656,9 +654,8 @@
             <p permid="DhS">
               The
               <term>contrapositive</term>
-              <idx>
-              <h>contrapositive</h>
-              </idx> of an implication
+                  <idx><h>contrapositive</h></idx>
+              of an implication
               <m>P \imp Q</m> is the statement
               <m>\neg Q \imp \neg P</m>.
               An implication and its contrapositive are logically equivalent
@@ -1019,10 +1016,8 @@
 
     <assemblage permid="GTw">
       <title>Necessary and Sufficient</title>
-      <p permid="Igg">
-            <idx> <h>necessary condition</h> </idx>
-            <idx> <h>sufficient condition</h> </idx>
-      </p>
+        <idx><h>necessary condition</h></idx>
+        <idx><h>sufficient condition</h></idx>
 
       <p permid="onp">
         <ul permid="YBB">
@@ -1163,23 +1158,15 @@
 
     <assemblage permid="naF">
       <title>Universal and Existential Quantifiers</title>
-      <p permid="sXi">
-        <idx>
-        <h>quantifiers</h>
-        </idx>
-      </p>
+        <idx><h>quantifiers</h></idx>
 
       <p permid="Zer">
         The existential quantifier is
         <m>\exists</m> and is read
         <q>there exists</q> or
-        <q>there is.</q> For example,<idx>
-        <h>existential quantifier</h>
-        </idx>
-        <idx>
-        <h>quantifiers</h>
-        <h>exists</h>
-        </idx>
+        <q>there is.</q> For example,
+            <idx><h>existential quantifier</h></idx>
+            <idx><h>quantifiers</h><h>exists</h></idx>
 
         <notation>
           <usage>\exists</usage>
@@ -1196,13 +1183,9 @@
         The universal quantifier is
         <m>\forall</m> and is read
         <q>for all</q> or
-        <q>every.</q> For example,<idx>
-        <h>universal quantifier</h>
-        </idx>
-        <idx>
-        <h>quantifiers</h>
-        <h>for all</h>
-        </idx>
+        <q>every.</q> For example,
+            <idx><h>universal quantifier</h></idx>
+            <idx><h>quantifiers</h><h>for all</h></idx>
 
         <notation>
           <usage>\forall</usage>

--- a/ptx/sec_logic-proofs.ptx
+++ b/ptx/sec_logic-proofs.ptx
@@ -266,9 +266,7 @@
 
   <subsection permid="BlB">
     <title>Direct Proof</title>
-    <p permid="zpk">
-          <idx><h>direct proof</h></idx>
-    </p>
+      <idx><h>direct proof</h></idx>
 
     <p permid="fwt">
       The simplest
@@ -393,10 +391,8 @@
 
   <subsection permid="hsK">
     <title>Proof by Contrapositive</title>
-    <p permid="XRU">
-          <idx><h>contrapositive</h><h>proof by</h></idx>
-          <idx><h>proof by contrapositive</h></idx>
-    </p>
+      <idx><h>contrapositive</h><h>proof by</h></idx>
+      <idx><h>proof by contrapositive</h></idx>
 
     <p permid="DZd">
       Recall that an implication
@@ -571,10 +567,8 @@
 
   <subsection permid="NzT">
     <title>Proof by Contradiction</title>
-    <p permid="cBN">
-          <idx><h>contradiction</h></idx>
-          <idx><h>proof by contradiction</h></idx>
-    </p>
+      <idx><h>contradiction</h></idx>
+      <idx><h>proof by contradiction</h></idx>
 
     <p permid="IIW">
       There might be statements which really cannot be rephrased as implications.
@@ -681,9 +675,9 @@
     <example permid="DaO">
       <statement>
         <p permid="JOp">
-          The Pigeonhole Principle
-              <idx><h>Pigeonhole principle</h></idx>
-          : If more than <m>n</m> pigeons fly into <m>n</m> pigeon holes,
+          The <term>Pigeonhole Principle</term>:
+              <idx><h>pigeonhole principle</h></idx>
+          If more than <m>n</m> pigeons fly into <m>n</m> pigeon holes,
           then at least one pigeon hole will contain at least two pigeons.
           Prove this!
         </p>
@@ -714,9 +708,7 @@
 
   <subsection permid="tHc">
     <title>Proof by (counter) Example</title>
-    <p permid="Bex">
-          <idx><h>counterexample</h></idx>
-    </p>
+      <idx><h>counterexample</h></idx>
 
     <p permid="hlG">
       It is almost NEVER okay to prove a statement with just an example.
@@ -855,10 +847,8 @@
 
   <subsection permid="ZOl">
     <title>Proof by Cases</title>
-    <p permid="lVz">
-          <idx><h>cases</h></idx>
-          <idx><h>proof by cases</h></idx>
-    </p>
+      <idx><h>cases</h></idx>
+      <idx><h>proof by cases</h></idx>
 
     <p permid="ScI">
       We could go on and on and on about different proof styles


### PR DESCRIPTION
We need to do some tidying up before saving the current tree of permids.
I saw that there were some "p" paragraphs that only contained index entries,
so I deleted the "p wrappers.  Since I was in the neighborhood I also cleaned
up some other things with idxs.
