### PR TITLE
Typo in gt-paths.ptx

### DIFF
--- a/source/exercises/gt-paths.ptx
+++ b/source/exercises/gt-paths.ptx
@@ -51,7 +51,7 @@
         <ol cols="6">
           <li><m>K_4</m></li>
 
-          <li><m>K_5</m>.</li>
+          <li><m>K_5</m></li>
 
           <li><m>K_{5,7}</m></li>
 


### PR DESCRIPTION
Remove stray period that looked like a math symbol