### PR TITLE
typo in rq for sec_gt-paths

### DIFF
--- a/source/sec_gt-paths.ptx
+++ b/source/sec_gt-paths.ptx
@@ -578,7 +578,7 @@
     <exercise label="rq-gt-paths-trees">
       <statement>
         <p>
-          Can a tree have an Euler tour?  Can a tree have an Euler circuit?  Explain your answers.
+          Can a tree have an Euler trail?  Can a tree have an Euler circuit?  Explain your answers.
         </p>
       </statement>
       <response/>


### PR DESCRIPTION
I think you meant Euler trail vs Euler circuit?  You defined Euler tour as a synonym for Euler circuit, so this currently asks the same question twice.  Which also worked for getting students reading and thinking but maybe not in the way you intended! :-)