### PR TITLE
Typo fix in graph coloring exercise

### DIFF
--- a/source/exercises/gt-coloring.ptx
+++ b/source/exercises/gt-coloring.ptx
@@ -163,7 +163,7 @@
 
             <row>
               <cell right="minor">Conflicts</cell>
-              <cell>CFJ</cell>
+              <cell>CFI</cell>
               <cell>J</cell>
               <cell>AEF</cell>
               <cell>H</cell>


### PR DESCRIPTION
In [this exercise](https://discrete.openmathbooks.org/dmoi4/sec_coloring.html#exercises_gt-coloring-5), my student spotted a small typo: vertex A is listed as adjacent to vertex J, but it evidently should be adjacent to vertex I instead. 