### PR TITLE
Update stale link + minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This text is written in [PreTeXt](https://pretextbook.org), so the primary sourc
 
 ### Preliminaries
 
-The easiest way to build output formats from the source is to use the PreTeXt-CLI. To get this set up, follow the instructions in the [PreTeXt guide](https://pretextbook.org/doc/guide/html/quickstart-getting-pretext.html). You will need Python, LaTeX, and `pdf2svg` (if you wish to compile the html version; this requires an [extra step](https://pretextbook.org/doc/guide/html/section-installing-pdf2svg.html) on Windows).
+The easiest way to build output formats from the source is to use the PreTeXt-CLI. To get this set up, follow the instructions in the [PreTeXt guide](https://pretextbook.org/quick-start.html). You will need Python, LaTeX, and `pdf2svg` (if you wish to compile the html version; this requires an [extra step](https://pretextbook.org/doc/guide/html/section-installing-pdf2svg.html) on Windows).
 
 Open up a terminal and in your preferred directory, clone `discrete-book` repositories:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This text is written in [PreTeXt](https://pretextbook.org), so the primary sourc
 
 ### Preliminaries
 
-The easiest way to build output formats from the source is to use the PreTeXt-CLI. To get this set up, follow the instructions in the [PreTeXt guide](https://pretextbook.org/quick-start.html). You will need Python, LaTeX, and `pdf2svg` (if you wish to compile the html version; this requires an [extra step](https://pretextbook.org/doc/guide/html/section-installing-pdf2svg.html) on Windows).
+The easiest way to build output formats from the source is to use the PreTeXt-CLI. To get this set up, follow the instructions in the [PreTeXt guide](https://pretextbook.org/quick-start.html). You will need Python, and LaTeX.
 
 Open up a terminal and in your preferred directory, clone `discrete-book` repositories:
 

--- a/source/practice/counting-combine-outcomes.ptx
+++ b/source/practice/counting-combine-outcomes.ptx
@@ -63,7 +63,7 @@
             </li>
             <li>
               <p>
-                How many subsets of cardinality <m><var name="$c"/></m> have <m>>\{2,3,5\}</m> as a subset?
+                How many subsets of cardinality <m><var name="$c"/></m> have <m>\{2,3,5\}</m> as a subset?
               </p>
               <p>
                 <var name="$ans2" width="10"/>


### PR DESCRIPTION
This PR has two commits:

---
1. 87a62681b2bc0c78c8eba0a9ad191b6076fddac1 updates a stale 404-ing link in the README.
---
2. dca749f42bd7d983913b43961b69362b3fa83789 fixes a minor typo in practice problem 3.2.6.5.b.

Typo: 
<img width="1117" height="288" alt="image" src="https://github.com/user-attachments/assets/d8cb0036-f23b-4853-a0ea-4fb7ed4af96c" />

The $>$ in 5.b is extraneous